### PR TITLE
카카오페이 연동 일부 로직 및 공용 로직 구현

### DIFF
--- a/src/main/java/com/mars/common/config/MarsConfig.java
+++ b/src/main/java/com/mars/common/config/MarsConfig.java
@@ -1,0 +1,20 @@
+package com.mars.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MarsConfig {
+
+  public static final ObjectMapper MAPPER = new ObjectMapper()
+          .registerModule(new JavaTimeModule())
+          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+  @Bean(name = "objectMapper")
+  public ObjectMapper objectMapper() {
+    return MAPPER;
+  }
+}

--- a/src/main/java/com/mars/common/constant/CommonExceptionInfo.java
+++ b/src/main/java/com/mars/common/constant/CommonExceptionInfo.java
@@ -10,6 +10,8 @@ public enum CommonExceptionInfo {
   INVALID_INPUT_VALUE("올바르지 않은 입력값입니다.", HttpStatus.BAD_REQUEST),
   INVALID_TYPE_VALUE("올바르지 않은 타입이 입력되었습니다.", HttpStatus.BAD_REQUEST),
   METHOD_NOT_ALLOWED("해당 메서드를 사용할 수 없습니다.", HttpStatus.BAD_REQUEST),
+
+  CANNOT_PARSE_URL_PARAMETER("url parameter 변환 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
   UNKNOWN_EXCEPTION("알 수 없는 에러가 발생했습니다.", HttpStatus.BAD_REQUEST);
 
   private final String message;

--- a/src/main/java/com/mars/common/util/MultiValueMapConverter.java
+++ b/src/main/java/com/mars/common/util/MultiValueMapConverter.java
@@ -1,0 +1,23 @@
+package com.mars.common.util;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mars.common.constant.CommonExceptionInfo;
+import java.util.Map;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+public interface MultiValueMapConverter {
+
+  static MultiValueMap<String, String> convert(ObjectMapper mapper, Object dto) {
+    try {
+      MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+      Map<String, String> map = mapper.convertValue(dto, new TypeReference<>() {});
+      params.setAll(map);
+
+      return params;
+    } catch (Exception e) {
+      throw CommonExceptionInfo.CANNOT_PARSE_URL_PARAMETER.exception();
+    }
+  }
+}

--- a/src/main/java/com/mars/payment/kakao/infra/KakaoPayRepositoryImpl.java
+++ b/src/main/java/com/mars/payment/kakao/infra/KakaoPayRepositoryImpl.java
@@ -1,15 +1,50 @@
 package com.mars.payment.kakao.infra;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mars.payment.kakao.domain.repository.KakaoPayRepository;
 import com.mars.payment.kakao.presentation.dto.KakaoApprove;
 import com.mars.payment.kakao.presentation.dto.KakaoInquiry;
-import com.mars.payment.kakao.presentation.dto.KakaoPrepare.Request;
+import com.mars.payment.kakao.presentation.dto.KakaoPrepare;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
 
+@Repository
+@RequiredArgsConstructor
 public class KakaoPayRepositoryImpl implements KakaoPayRepository {
 
-  @Override
-  public void preparePayment(Request request) {
+  private static final String KAKAO_HOST = "https://kapi.kakao.com";
 
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void preparePayment(KakaoPrepare.Request request) {
+    final var restTemplate = new RestTemplate();
+    final var headers = getKakaoPayHeader();
+    final var params = KakaoPrepare.convertToMap(request, objectMapper);
+    final var body = new HttpEntity<>(params, headers);
+
+    try {
+      restTemplate.postForLocation(getKakaoPayPrepareUrl(), body);
+    } catch (RestClientException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private String getKakaoPayPrepareUrl() {
+    return KAKAO_HOST + "/v1/payment/order";
+  }
+
+  private static HttpHeaders getKakaoPayHeader() {
+    final var headers = new HttpHeaders();
+    headers.add("Authorization", "KakaoAK " + "cc062a76b9cd620043a26fd72b5f8c8d");
+    headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+    headers.add("Content-Type", MediaType.APPLICATION_FORM_URLENCODED_VALUE + ";charset=UTF-8");
+    return headers;
   }
 
   @Override

--- a/src/main/java/com/mars/payment/kakao/presentation/dto/KakaoPrepare.java
+++ b/src/main/java/com/mars/payment/kakao/presentation/dto/KakaoPrepare.java
@@ -1,11 +1,14 @@
 package com.mars.payment.kakao.presentation.dto;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mars.common.util.MultiValueMapConverter;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.util.MultiValueMap;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class KakaoPrepare {
@@ -40,4 +43,9 @@ public class KakaoPrepare {
     private String iosAppScheme; // 결제 화면으로 이동하는 ios 앱 스킴
     private LocalDateTime createdAt; // 결제 준비 요청 시간
   }
+
+  public static MultiValueMap<String, String> convertToMap(KakaoPrepare.Request request, ObjectMapper objectMapper) {
+    return MultiValueMapConverter.convert(objectMapper, request);
+  }
 }
+


### PR DESCRIPTION
아래 작업 수행했습니다
- ObjectMapper 빈 등록
- 카카오 페이 결제 준비 일부 로직 구현

DTO to MultiValueMap 컨버터 및 RestTemplate 사용해 post api 요청하는 메서드가 통일성 있게 구성되면 좋을 것 같아, 아직 완료되지 않은 작업임에도 PR 올립니다.